### PR TITLE
Handle placeholder Azure secrets in CI workflow

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -27,8 +27,9 @@ jobs:
         run: |
           missing=false
           for secret in ARM_CLIENT_ID ARM_TENANT_ID ARM_SUBSCRIPTION_ID ARM_CLIENT_SECRET ACR_NAME ACR_LOGIN_SERVER; do
-            if [ -z "${!secret}" ]; then
-              echo "::warning::Secret $secret is not set. Azure login and push steps will be skipped."
+            value="${!secret}"
+            if [ -z "$value" ] || [ "$value" = "undefined" ] || [ "$value" = "null" ]; then
+              echo "::warning::Secret $secret is not configured. Azure login and push steps will be skipped."
               missing=true
             fi
           done


### PR DESCRIPTION
## Summary
- treat unset or placeholder Azure secrets as missing during CI validation to avoid running login steps without credentials

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc475335d08322b57fcd46f2637d8b