### PR TITLE
Add workflow permissions for build job

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 env:
   IMAGE_NAME: splunk-ai-agent
 


### PR DESCRIPTION
## Summary
- configure the Docker build workflow to request contents, pages, and id-token permissions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc4a5b1d848322b2f3a52347f45025