### PR TITLE
Allow per-request Splunk SSL and timeout overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ curl -X POST http://localhost:8000/ask \
      -d '{"question":"Show failed logins last 24h","splunk_host":"splunk.backup.local"}'
 ```
 
+You can also override SSL verification or the Splunk request timeout for a single call:
+
+```bash
+curl -X POST http://localhost:8000/ask \
+     -H "Content-Type: application/json" \
+     -d '{"question":"Show failed logins last 24h","splunk_verify_ssl":false,"splunk_request_timeout":120}'
+```
+
 ### Docker
 
 Build and run the Docker image locally:


### PR DESCRIPTION
## Summary
- add optional `splunk_verify_ssl` and `splunk_request_timeout` overrides to the `/ask` request model
- instantiate a per-request Splunk client when overrides are provided
- document the new request fields in the README example

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df68947be88322b9d38eb1418aca6a